### PR TITLE
fix: update format of ios appstore url

### DIFF
--- a/lib/src/force_update_client.dart
+++ b/lib/src/force_update_client.dart
@@ -60,7 +60,7 @@ class ForceUpdateClient {
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       // * On iOS, use the given app ID
       return iosAppStoreId.isNotEmpty
-          ? 'https://apps.apple.com/app/id$iosAppStoreId'
+          ? 'https://apps.apple.com/app/id/$iosAppStoreId'
           : null;
     } else if (defaultTargetPlatform == TargetPlatform.android) {
       final packageInfo = await PackageInfo.fromPlatform();


### PR DESCRIPTION
The ios appstore url needs to have `/` to work properly.